### PR TITLE
check_snmp_extend.sh

### DIFF
--- a/check_snmp_extend.sh
+++ b/check_snmp_extend.sh
@@ -68,7 +68,7 @@ HOST_ARG=$(${SELFDIRNAME}resolve-v4v6.pl --host ${HOST} --wrap-v6)
 
 RESULT=$(${SNMPGET} -v2c -c public -OvQ ${HOST_ARG} NET-SNMP-EXTEND-MIB::nsExtendOutputFull.\"${NAME}\" 2>&1)
 
-STATUS=$(echo $RESULT | cut -d\  -f1)
+STATUS=$(echo $RESULT | awk -F[\ \:\-] '{print $1}')
 
 case "$STATUS" in
 	OK|WARNING|CRITICAL|UNKNOWN)


### PR DESCRIPTION
Changed how STATUS is formed, uses awk instead of cut so now STATUS can use space, dash or colon as separator for OK|WARNING|CRITICAL from the rest of output.
