### PR TITLE
Update check_snmp_exec.sh

### DIFF
--- a/check_snmp_exec.sh
+++ b/check_snmp_exec.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Nagios "check" for querying output of scripts
 # from remote servers via SNMP "exec" mechanism.


### PR DESCRIPTION
this script is not compatible with sh .. if you run it with sh you get errors like './check_snmp_exec.sh: 82: ./check_snmp_exec.sh: Bad substitution'

works with bash, though.
