### PR TITLE
Fixed path variable to work with Windows machines

### DIFF
--- a/check_snmp_disk.pl
+++ b/check_snmp_disk.pl
@@ -174,6 +174,10 @@ foreach my $key (keys(%$result)) {
 # based on the include and exlude options
 foreach my $key (keys(%disks)) {
   my $path = $disks{$key}{path};
+  # Fix path variable to work with Windows machines
+  if ($path =~ /([A-Z]:.*|Physical Memory|Virtual Memory)/) {
+    $path = $key;
+  }
   if(@opt_include) {
     my $is_included = 0;
     foreach my $include (@opt_include) {


### PR DESCRIPTION
The path representation of file mounts (or drives rather), are represented differently
than that of *NIX systems, i.e:

C:\ Label:OS  Serial Number 0a1b2c4d
D:\ Label:New Volume  Serial Number 5a6b7c8d
Physical Memory
Virtual Memory

So to fix this, we just rewrite the path variable if we encounter this when parsing
the include(s) and/or exclude(s).