### PR TITLE
Fix check-mysql-slave.pl for modern Perl versions

### DIFF
--- a/check-mysql-slave.pl
+++ b/check-mysql-slave.pl
@@ -97,8 +97,8 @@ sub nagios_return($$) {
 		$message = "WTF is return code '$ret'??? ($message)";
 	}
 	$message = "$retstr - $message\n";
-	$! = $retval;
-	die ($message);
+	print $message;
+	exit($retval);
 }
 
 sub usage() {


### PR DESCRIPTION
This is improper use of `die()`; as per perldoc, `exit()` should be used to exit a program with specific exit code, see very first paragraph here: http://perldoc.perl.org/functions/die.html 