### PR TITLE
fix for security patch detection

### DIFF
--- a/check-apt-upgrade.pl
+++ b/check-apt-upgrade.pl
@@ -29,7 +29,7 @@ while (<>) {
 		$filelist =~ s/\s+/ /g;
 		$filelist .= " ";
 	}
-	if (/^Inst ([^\s]+).*security.*\)$/) {
+	if (/^Inst ([^\s]+).*[Ss]ecurity.*\)$/) {
 		$critical++;
 		$filelist =~ s/ ($1) / $1\[S\] /g;
 	}


### PR DESCRIPTION
I found the following on my Debian jessi system:
apache2-utils [2.4.10-10+deb8u7] (2.4.10-10+deb8u8 Debian-Security:8/stable

so I patched the regex for security detection to work with Security and security. 

Please have a look an merge my changes. 

Best regards
Marcus